### PR TITLE
Fix for GRAILSPLUGINS-2579

### DIFF
--- a/MultiTenantCoreGrailsPlugin.groovy
+++ b/MultiTenantCoreGrailsPlugin.groovy
@@ -198,7 +198,7 @@ class MultiTenantCoreGrailsPlugin {
       application.domainClasses.each {DefaultGrailsDomainClass domainClass ->
         domainClass.constraints?.get("tenantId")?.applyConstraint(ConstrainedProperty.NULLABLE_CONSTRAINT, true);
         domainClass.clazz.metaClass.beforeInsert = {
-          if (tenantId == null) tenantId = 0
+          if (delegate.respondsTo("tenantId") && tenantId == null) { tenantId = 0 }
         }
       }
     }


### PR DESCRIPTION
Hi,

This fixes the "GRAILSPLUGINS-2579" issue that I've opened a couple months ago. When we have non annotated domain classes and uses singleTenant mode, those classes do not have the "tenantId" property, but the beforeInsert closure on "MultiTenantCoreGrailsPlugin" wasn't checking for this, so when the application tries to save one instance of these classes, it blows with an exception:

groovy.lang.MissingPropertyException: No such property: tenantId for class: MultiTenantGrailsPlugin

Hope you guys can incorporate this, and maybe get a minor release for this, it is very important and crutial for ppl using singleTenant mode.

So, this is my contribution, we're already using this correction and working great.
